### PR TITLE
Fix setComfortPlug function to work with new firmware

### DIFF
--- a/src/SmappeeLocal.php
+++ b/src/SmappeeLocal.php
@@ -115,7 +115,7 @@ class SmappeeLocal
 	
 	public function setComfortPlug($plug_id=1, $plug_status=1) 
     {
-		$body = 'control,controlId='.$plug_id.'|'.$plug_status;
+		$body = 'control,controlId='.$plug_status.'|'.$plug_id;
 		$result = $this->_postCall('/gateway/apipublic/commandControlPublic', $body);
 
         $data = json_decode($result->getBody(), true);

--- a/src/SmappeeLocal.php
+++ b/src/SmappeeLocal.php
@@ -61,15 +61,12 @@ class SmappeeLocal
             throw new \Exception("You must set the local Smappee device address and the password to access it.");
         }
         
-        $url = "http://{$host}".$uri;
-
 		$result = $client->request('POST', $url, [
             'headers' => [
                 'Content-Type' => 'application/json'
             ],
             'body' => $body
         ]);
-        
         return $result;
 
 	}
@@ -80,7 +77,7 @@ class SmappeeLocal
 	}
     
     public function getInstantaneous()
-    {            
+    {
         $result = $this->_postCall('/gateway/apipublic/instantaneous', 'loadInstantaneous');
         
         $data = json_decode($result->getBody(), true);
@@ -115,10 +112,17 @@ class SmappeeLocal
 	
 	public function setComfortPlug($plug_id=1, $plug_status=1) 
     {
-		$body = 'control,controlId='.$plug_status.'|'.$plug_id;
+		if ($plug_status) {
+			$plug_action = 'ON';
+		} else {
+			$plug_action = 'OFF';
+		}
+		$body = 'control,{"controllableNodeId":"'.$plug_id.'","action":"'.$plug_action.'"}';
 		$result = $this->_postCall('/gateway/apipublic/commandControlPublic', $body);
 
         $data = json_decode($result->getBody(), true);
+        
+        var_dump($data);
         
         $retval = [];
 


### PR DESCRIPTION
Hi,

There was a firmware upgrade of the Smappee enegry meter that broke the setComfortPlug function. This change fixes the function to use the new format of the API call to work with the new firmware.

Cheers!

Jeroen